### PR TITLE
[ci skip] Fix a typo in doc

### DIFF
--- a/doc/src/manual/parallel-computing.md
+++ b/doc/src/manual/parallel-computing.md
@@ -65,7 +65,7 @@ A channel can be visualized as a pipe, i.e., it has a write end and a read end :
     c1 = Channel(32)
     c2 = Channel(32)
 
-    # and a function `foo` which reads items from from c1, processes the item read
+    # and a function `foo` which reads items from c1, processes the item read
     # and writes a result to c2,
     function foo()
         while true


### PR DESCRIPTION
Mentioned in [#29510](https://github.com/JuliaLang/julia/issues/29510#issuecomment-426959229).